### PR TITLE
Fixed: Examples check arguments in wrong order

### DIFF
--- a/README.org
+++ b/README.org
@@ -205,7 +205,7 @@
       int send_name(int sock, const char *name)
       {
         printf ("%s: SENDING \"%s\"\n", name, name);
-        int sz_n = strlen (name) + 1; // '\0' too
+        int sz_n = (int)strlen (name) + 1; // '\0' too
         return nn_send (sock, name, sz_n, 0);
       }
 
@@ -253,9 +253,9 @@
 
       int main (const int argc, const char **argv)
       {
-        if (strncmp (NODE0, argv[1], strlen (NODE0)) == 0 && argc > 1)
+        if ((argc > 2) && (strncmp (NODE0, argv[1], strlen (NODE0)) == 0))
           return node0 (argv[2]);
-        else if (strncmp (NODE1, argv[1], strlen (NODE1)) == 0 && argc > 1)
+        else if ((argc > 2) && (strncmp (NODE1, argv[1], strlen (NODE1)) == 0))
           return node1 (argv[2]);
         else
           {


### PR DESCRIPTION
Fixed crash in the "Pair (Two way radio)" example when it got started without arguments. 
Fixed size_t/int warning.
